### PR TITLE
Added extra note to readme to prevent auto discovery from not working

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ This integration can be installed via HACS for Home Assistant
     1. Click 'Download' and follow on-screen instructions
     -->
 1. Once the plugin is installed via HACS configure it just like a normal Home Assistant Integration i.e. from Settings -> Devices & Settings -> Add Integration -> Search for Grott
+1. Make sure your MQTT topic is set to energy/growatt (default in Grott) otherwise the discovery of your data won't work.
 
 or (if you don't want to use HACS)
 


### PR DESCRIPTION
I had issues setting this up at first. I used to set my topic in Grott config.ini to 'growatt' instead of 'energy/growatt'.
Since this add-on specific only searches in 'energy/growatt', it couldn't find my MQTT data. 

I wasn't able to find any note about this, so decided to add it to the readme for now.
Might be better if you could configure it in HA.